### PR TITLE
Overflow wrap

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -5,3 +5,8 @@
 	height: 30px;
 	width: 30px;
 }
+
+.container {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Break very long words and links so that they don't stretch the page horizontally beyond the viewport.